### PR TITLE
Add EnvInputHeadingAccPolicy.

### DIFF
--- a/metadrive/policy/env_input_policy.py
+++ b/metadrive/policy/env_input_policy.py
@@ -1,6 +1,9 @@
-from metadrive.policy.base_policy import BasePolicy
-from metadrive.utils.math_utils import clip
+import logging
 from collections.abc import Iterable
+
+from metadrive.component.vehicle_module.PID_controller import PIDController
+from metadrive.policy.base_policy import BasePolicy
+from metadrive.utils.math_utils import clip, wrap_to_pi
 
 
 class EnvInputPolicy(BasePolicy):
@@ -41,3 +44,59 @@ class EnvInputPolicy(BasePolicy):
 
             # print("Steering: ", steering, " Throttle: ", throttle)
         return steering, throttle
+
+
+class EnvInputHeadingAccPolicy(EnvInputPolicy):
+
+    def __init__(self, obj, seed):
+        super(EnvInputPolicy, self).__init__(obj, seed)
+        self.heading_pid = PIDController(1.7, 0.01, 3.5)
+    
+    def act(self, agent_id):
+        """The action space of this policy is [heading angle, acc].
+
+        The input `heading angle` needs to be converted to steering angle, following
+        the definition of metadrive physical engine.
+        NOTE: the heading angle's unit must be RADIUS!
+
+        Args:
+            agent_id: the ID of the ego car.
+        
+        Returns:
+            action: [steering, acc]
+        """
+        action = self.engine.external_actions[agent_id]
+
+        if not self.discrete_action:
+            to_process = action
+        else:
+            to_process = self.convert_to_continuous_action(action)
+
+        steering = self.steering_control(to_process[0])
+        acc = to_process[1]
+        action = [steering, acc]
+        action = self.postprocess_action(action)
+        self.action_info["action"] = action
+        return action
+
+    def postprocess_action(self, action):
+        for i in range(len(action)):
+            if -1. < action[i] < 1.:
+                logging.warning(
+                    f"Action {str(i)} == {str(action[i])} is out of bound!"
+                    " Clipped to [-1., 1.]."
+                )
+                action[i] = clip(action[i], -1., 1.)
+        return action
+
+
+    def steering_control(self, target_heading: float) -> float:
+        """Convert target heading to steering angle by a PID.
+
+        Args: 
+            target_heading: the target heading angle, which unit is radius.
+        """
+        ego_vehicle = self.control_object
+        v_heading = ego_vehicle.heading_theta
+        steering = self.heading_pid.get_result(target_heading - wrap_to_pi(v_heading))
+        return float(steering)


### PR DESCRIPTION
This policy enables the env to accept `[heading angle, acceleration]` as action input. The heading angle is converted to steering angle by a PID controller, and then a compatible action `[steering angle, acceleration]` is fed into the simulator.

`EnvInputHeadingAccPolicy` is to used as 'agent_policy' in the environment config during RL or BC training AND evaluation.

## Please note: 
- The heading angle should use RADIUS as unit. Please preprocess the waymo dataset to obtain radius heading angle as well! I think obtaining radius heading from waymo dataset is easier by np.atan2.

- Please confirm that `ego_vehicle.heading_theta` in line 100 of `metadrive/policy/env_input_policy.py` is in the global coordinate. Make sure the preprocessed heading angle from waymo dataset and `ego_vehicle.heading_theta` are in the same coordinate system (either local or global).