### PR TITLE
Fix PMKinematicsPolicy

### DIFF
--- a/metadrive/policy/replay_policy.py
+++ b/metadrive/policy/replay_policy.py
@@ -2,7 +2,6 @@ import numpy as np
 from metadrive.utils.math_utils import wrap_to_pi
 
 from metadrive.policy.base_policy import BasePolicy
-from metadrive.component.vehicle_model.point_mass_model import PointMassModel 
 has_rendered = False
 
 # class ReplayPolicy(BasePolicy):
@@ -81,40 +80,74 @@ class ReplayEgoCarPolicy(BasePolicy):
 class PMKinematicsEgoPolicy(BasePolicy):
     def __init__(self, control_object, random_seed):
         super(PMKinematicsEgoPolicy, self).__init__(control_object=control_object)
-        self.dt = 0.1 # waymo dataset timestep
-        
-        self.model = PointMassModel(x = 0, 
-                                    y = 0, 
-                                    speed = 0, 
-                                    heading_theta = 0)
+        self.waymo_dt = 0.1 # waymo dataset timestep
+        self.dt = self.engine.global_config["physics_world_step_size"]
+        if not self.waymo_dt / self.dt == int(self.waymo_dt / self.dt):
+            raise ValueError(
+                "The physics world step size must be a divisor of waymo dataset step size!"
+                f" Currently physics world step size is {self.dt}, while waymo dataset step"
+                f" size is {self.waymo_dt}."
+            )
 
     def act(self,  agent_id):
-        
-        # action = [heading, acceleration]
         action = self.engine.external_actions[agent_id]
         if not self.discrete_action:
             control = action
         else:
             control = self.convert_to_continuous_action(action)
 
-        
-
-        pos = self.engine.agent_manager.active_agents['default_agent'].position
-        vel = self.engine.agent_manager.active_agents['default_agent'].velocity
+        pos = self.control_object.position
+        vel = self.control_object.velocity
         speed = np.linalg.norm(vel)
+        heading_theta = self.control_object.heading_theta
+
         # overwrite dynamics
-        self.model.reset(x = pos[0], 
-                         y = pos[1], 
-                         speed = speed, 
-                         heading_theta = 0)
-       
-        next_state = self.model.step(self.dt, control)
+        state = {
+                'x': pos[0],
+                'y': pos[1],
+                'speed': speed,
+                'heading_theta': heading_theta,
+        }
+        num_skip_frames = int(self.waymo_dt / self.dt)
+        for _ in range(num_skip_frames):
+            state = self.step_point_mass_kinematics(state, control, self.dt)
+        next_state = state
+
         self.control_object.set_position([next_state['x'], next_state['y']])
-        self.control_object.set_velocity([next_state['speed'] * np.cos(next_state['heading_theta']),
-                                          next_state['speed'] * np.sin(next_state['heading_theta'])] )
+        self.control_object.set_velocity(
+            [
+                next_state['speed'] * np.cos(next_state['heading_theta']),
+                next_state['speed'] * np.sin(next_state['heading_theta']),
+            ],
+        )
         self.control_object.set_heading_theta(next_state['heading_theta'], rad_to_degree=False)
 
         return [0, 0]
+
+    @staticmethod
+    def step_point_mass_kinematics(
+            state: dict[str, float], action: list, dt: float
+    ) -> dict[str, float]:
+        """Obtain next state by the kinematics model.
         
+        Args: 
+            state: {pos_x, pos_y, speed, heading_angle}
+            action: [heading_angle, acc]
+            dt: sampling time
+        Returns:
+            next_state: the next state.        
+        """
+        x, y = state["x"], state["y"]
+        v = state["speed"]
+        # TODO(lijinning): Should we use heading as BC output?
+        theta = state["heading_theta"]
+        heading, acc = action
+        
+        new_theta = heading
+        new_v = v + acc * dt
+        new_x = x + new_v * np.cos(new_theta) * dt
+        new_y = y + new_v * np.sin(new_theta) * dt
+        new_state = dict(x=new_x, y=new_y, speed=new_v, heading_theta=new_theta)
+        return new_state
 
         


### PR DESCRIPTION
The policy gets action inputs from behavior cloning policy trained by the waymo dataset. It has to adapt to the gap between waymo dataset step size and the physics world engine step size.

Also, I removed the PointMassVehicleModel, and replaced it by a function to make the code more concise. I don't think we need a whole class to do kinematics step if we have to reset the state of that class every time before we call the `step` function.